### PR TITLE
[server] feat : 퀴즈에서 노래 삭제하는 API추가 /youtube/{qsRelationId}/delSong

### DIFF
--- a/MUTCHIGI/src/main/java/com/CAUCSD/MUTCHIGI/song/SongController.java
+++ b/MUTCHIGI/src/main/java/com/CAUCSD/MUTCHIGI/song/SongController.java
@@ -75,6 +75,10 @@ public class SongController {
     }
 
     @GetMapping("/youtube/hintCount")
+    @Operation(summary = "해당 퀴즈의 힌트 개수를 확인할 수 있는 API",
+    description = """
+            해당 퀴즈가 총 몇개의 힌트를 주도록 정해두었는 지 확인 할 수 있는 API이다.
+            """)
     public ResponseEntity<Integer> getHintCount(
             @RequestParam long quizId
     ){
@@ -84,6 +88,11 @@ public class SongController {
     }
 
     @PostMapping("/youtube/{qsRelationId}/hint")
+    @Operation(summary = "해당 퀴즈에 포함된 노래에 대한 퀴즈를 저장하는 API, 갯수는 위에서 확인함",
+            description = """
+                               /youtube/hintCount에서 얻은 퀴즈 갯수로 Front에서 예외처리를 일단 해야 한다.
+                               백엔드에서는 아직 구현되어 있지 않음. 구현되면 추가하겠음.
+                                """)
     public ResponseEntity<List<Long>> addHintList(
             @RequestBody List<HintDTO> hintDTOList,
             @PathVariable long qsRelationId
@@ -91,5 +100,19 @@ public class SongController {
         return ResponseEntity
                 .ok()
                 .body(songService.saveHintList(hintDTOList, qsRelationId));
+    }
+
+    @DeleteMapping("/youtube/{qsRelationId}/delSong")
+    @Operation(summary = "해당 퀴즈에 대한 노래(유튜브 영상)을 삭제하는 API", description =
+            """
+                    퀴즈-노래 사이의 관련성(qsRelation)만 삭제한다. 즉, 노래 정보나 가수 정보는 그대로 DB에 남아있어서 재활용이 가능하다.
+                    실제로 qsRelation만 삭제하고 같은 노래 URL을 넣으면 동일하기에 노래 DB에 있던 id를 그대로 반환한다.
+                    """)
+    public ResponseEntity<Void> deleteYoutubeSong(
+            @PathVariable long qsRelationId
+    ){
+        return ResponseEntity
+                .ok()
+                .body(songService.deleteYoutubeSongDB(qsRelationId));
     }
 }

--- a/MUTCHIGI/src/main/java/com/CAUCSD/MUTCHIGI/song/SongService.java
+++ b/MUTCHIGI/src/main/java/com/CAUCSD/MUTCHIGI/song/SongService.java
@@ -16,8 +16,11 @@ import com.CAUCSD.MUTCHIGI.song.singer.relation.SingerSongRelation;
 import com.CAUCSD.MUTCHIGI.song.singer.relation.SingerSongRelationRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityNotFoundException;
+import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -128,6 +131,19 @@ public class SongService {
             hintIdList.add(hintEntity.getHintId());
         }
         return hintIdList;
+    }
+
+    public Void deleteYoutubeSongDB(long qsRelationId){
+        quizSongRelationRepository.deleteById(qsRelationId);
+
+        // 삭제 후 확인
+        if (!quizSongRelationRepository.existsById(qsRelationId)) {
+            return null;
+            // 삭제가 성공적으로 이루어졌음
+        } else {
+            throw new EntityNotFoundException("ID가 " + qsRelationId + "인 항목을 찾을 수 없습니다.");
+            // 삭제에 실패했거나 항목이 존재하지 않음
+        }
     }
 
     private String extractYoutubeVideoId(String youtubeURL) {
@@ -244,6 +260,8 @@ public class SongService {
         }
         return startTime;
     }
+
+
 
 
 }


### PR DESCRIPTION
간단히 노래와 퀴즈사이의 관계성을 없애 해당 퀴즈에 노래가 좋속되지 않도록 한다.

노래 정보는 그대로 남아 있어 활용할 수 있다.