### PR TITLE
[server] feat : 권한문제 해결함

### DIFF
--- a/MUTCHIGI/src/main/java/com/CAUCSD/MUTCHIGI/quiz/QuizController.java
+++ b/MUTCHIGI/src/main/java/com/CAUCSD/MUTCHIGI/quiz/QuizController.java
@@ -70,6 +70,19 @@ public class QuizController {
         }
     }
 
+    @GetMapping("/Entity/restore")
+    @Operation(summary = "이어하기 혹은 쿼리문으로 조회할 때, 권한 확인")
+    public ResponseEntity<QuizEntity> getQuizEntity(
+            @RequestParam long quizId
+    ){
+        QuizEntity quizEntity = quizService.getQuizInStored(quizId);
+        if (quizEntity == null) {
+            return ResponseEntity.status(HttpStatus.SC_METHOD_NOT_ALLOWED).build();
+        }else{
+            return ResponseEntity.ok(quizEntity);
+        }
+    }
+
     @GetMapping("/images/{filename}")
     @Operation(summary = "퀴즈 썸네일 이미지를 inline으로 반환함",
     description = """
@@ -115,8 +128,16 @@ public class QuizController {
     public ResponseEntity<Long> setQuizToReady(
             @PathVariable long quizId
     ){
+        long quizReadyState = quizService.setQuizToReadyInDB(quizId);
+        if(quizReadyState == -2){
+            return ResponseEntity.status(HttpStatus.SC_NOT_FOUND).build();
+        }else if(quizReadyState == -1){
+            return ResponseEntity.status(HttpStatus.SC_METHOD_NOT_ALLOWED).build();
+        }else{
+            return ResponseEntity.status(HttpStatus.SC_OK).body(quizReadyState);
+        }
 
-        return ResponseEntity.status(HttpStatus.SC_OK).body(quizService.setQuizToReadyInDB(quizId));
+
     }
 
     @PostMapping(value = "/createQuiz/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/MUTCHIGI/src/main/java/com/CAUCSD/MUTCHIGI/quiz/QuizService.java
+++ b/MUTCHIGI/src/main/java/com/CAUCSD/MUTCHIGI/quiz/QuizService.java
@@ -103,6 +103,23 @@ public class QuizService {
         return quizEntities;
     }
 
+    public QuizEntity getQuizInStored(long quizId){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        UserEntity userEntity = userRepository.findByEmail(email);
+
+        QuizEntity quizEntity = quizRepository.findById(quizId).orElse(null);
+        if(quizEntity != null){
+            if(quizEntity.getUser() == userEntity){
+                return quizEntity;
+            }else{
+                return null;
+            }
+        }else{
+            return null;
+        }
+    }
+
     public Resource serveImageFromLocalStorage(String filename) throws  IOException{
         Path imageStoragePath = Paths.get(thumbnailDir);
         Path filePath = imageStoragePath.resolve(filename);
@@ -167,10 +184,16 @@ public class QuizService {
         return quizRepository.save(quizEntity);
     }
 
-    public Long setQuizToReadyInDB(long QuizId){
+    public long setQuizToReadyInDB(long QuizId){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        UserEntity userEntity = userRepository.findByEmail(email);
+
         QuizEntity quizEntity = quizRepository.findById(QuizId).orElse(null);
         if(quizEntity == null){
-            return null;
+            return -2;
+        }else if(quizEntity.getUser() != userEntity){
+            return -1;
         }
         quizEntity.setReadyToPlay(true);
         quizEntity.setReleaseDate(LocalDateTime.now());


### PR DESCRIPTION
이어하기 기능인 경우 퀴즈 정보를 불러올 때 기존의 Entities를 쓰지 말고 /Entity/restore 을 사용할 것

setReady도 권한 처리해둠